### PR TITLE
Refactor Session, support custom TransactionDataCache

### DIFF
--- a/language/extensions/async/move-async-vm/src/async_vm.rs
+++ b/language/extensions/async/move-async-vm/src/async_vm.rs
@@ -115,26 +115,26 @@ impl AsyncVM {
     }
 
     /// Creates a new session with given data store.
-    pub fn new_session_with_store<'r, 'l, D: DataStore + TransactionCache>(
+    pub fn new_session_with_cache<'r, 'l, D: DataStore + TransactionCache>(
         &'l self,
         for_actor: AccountAddress,
         virtual_time: u128,
-        data_store: D,
+        data_cache: D,
     ) -> AsyncSession<'r, 'l, D> {
-        self.new_session_with_store_and_extensions(
+        self.new_session_with_cache_and_extensions(
             for_actor,
             virtual_time,
-            data_store,
+            data_cache,
             NativeContextExtensions::default(),
         )
     }
 
     /// Creates a new session with given data store and extensions.
-    pub fn new_session_with_store_and_extensions<'r, 'l, D: DataStore + TransactionCache>(
+    pub fn new_session_with_cache_and_extensions<'r, 'l, D: DataStore + TransactionCache>(
         &'l self,
         for_actor: AccountAddress,
         virtual_time: u128,
-        data_store: D,
+        data_cache: D,
         ext: NativeContextExtensions<'r>,
     ) -> AsyncSession<'r, 'l, D> {
         let extensions = make_extensions(ext, for_actor, virtual_time, true);
@@ -142,7 +142,7 @@ impl AsyncVM {
             vm: self,
             vm_session: self
                 .move_vm
-                .new_session_with_store_and_extensions(data_store, extensions),
+                .new_session_with_cache_and_extensions(data_cache, extensions),
         }
     }
 

--- a/language/extensions/async/move-async-vm/src/async_vm.rs
+++ b/language/extensions/async/move-async-vm/src/async_vm.rs
@@ -18,7 +18,7 @@ use move_core_types::{
     vm_status::StatusCode,
 };
 use move_vm_runtime::{
-    data_cache::{TransactionCache, TransactionDataCache},
+    data_cache::TransactionDataCache,
     move_vm::MoveVM,
     native_extensions::NativeContextExtensions,
     native_functions::NativeFunction,
@@ -26,7 +26,7 @@ use move_vm_runtime::{
 };
 use move_vm_test_utils::gas_schedule::{Gas, GasStatus};
 use move_vm_types::{
-    data_store::DataStore,
+    data_store::{DataStore, TransactionCache},
     values::{Reference, Value},
 };
 

--- a/language/extensions/async/move-async-vm/src/async_vm.rs
+++ b/language/extensions/async/move-async-vm/src/async_vm.rs
@@ -18,13 +18,17 @@ use move_core_types::{
     vm_status::StatusCode,
 };
 use move_vm_runtime::{
+    data_cache::{TransactionCache, TransactionDataCache},
     move_vm::MoveVM,
     native_extensions::NativeContextExtensions,
     native_functions::NativeFunction,
     session::{SerializedReturnValues, Session},
 };
 use move_vm_test_utils::gas_schedule::{Gas, GasStatus};
-use move_vm_types::values::{Reference, Value};
+use move_vm_types::{
+    data_store::DataStore,
+    values::{Reference, Value},
+};
 
 use crate::{
     actor_metadata,
@@ -84,7 +88,7 @@ impl AsyncVM {
         for_actor: AccountAddress,
         virtual_time: u128,
         move_resolver: &'r mut S,
-    ) -> AsyncSession<'r, 'l, S> {
+    ) -> AsyncSession<'r, 'l, TransactionDataCache<'r, 'l, S>> {
         self.new_session_with_extensions(
             for_actor,
             virtual_time,
@@ -100,13 +104,45 @@ impl AsyncVM {
         virtual_time: u128,
         move_resolver: &'r mut S,
         ext: NativeContextExtensions<'r>,
-    ) -> AsyncSession<'r, 'l, S> {
+    ) -> AsyncSession<'r, 'l, TransactionDataCache<'r, 'l, S>> {
         let extensions = make_extensions(ext, for_actor, virtual_time, true);
         AsyncSession {
             vm: self,
             vm_session: self
                 .move_vm
                 .new_session_with_extensions(move_resolver, extensions),
+        }
+    }
+
+    /// Creates a new session with given data store.
+    pub fn new_session_with_store<'r, 'l, D: DataStore + TransactionCache>(
+        &'l self,
+        for_actor: AccountAddress,
+        virtual_time: u128,
+        data_store: D,
+    ) -> AsyncSession<'r, 'l, D> {
+        self.new_session_with_store_and_extensions(
+            for_actor,
+            virtual_time,
+            data_store,
+            NativeContextExtensions::default(),
+        )
+    }
+
+    /// Creates a new session with given data store and extensions.
+    pub fn new_session_with_store_and_extensions<'r, 'l, D: DataStore + TransactionCache>(
+        &'l self,
+        for_actor: AccountAddress,
+        virtual_time: u128,
+        data_store: D,
+        ext: NativeContextExtensions<'r>,
+    ) -> AsyncSession<'r, 'l, D> {
+        let extensions = make_extensions(ext, for_actor, virtual_time, true);
+        AsyncSession {
+            vm: self,
+            vm_session: self
+                .move_vm
+                .new_session_with_store_and_extensions(data_store, extensions),
         }
     }
 
@@ -159,7 +195,7 @@ pub struct AsyncError {
 /// Result type for operations of an AsyncSession.
 pub type AsyncResult<'r> = Result<AsyncSuccess<'r>, AsyncError>;
 
-impl<'r, 'l, S: MoveResolver> AsyncSession<'r, 'l, S> {
+impl<'r, 'l, S: DataStore + TransactionCache> AsyncSession<'r, 'l, S> {
     /// Get the underlying Move VM session.
     pub fn get_move_session(&mut self) -> &mut Session<'r, 'l, S> {
         &mut self.vm_session

--- a/language/extensions/async/move-async-vm/tests/testsuite.rs
+++ b/language/extensions/async/move-async-vm/tests/testsuite.rs
@@ -24,6 +24,7 @@ use move_core_types::{
     resolver::{ModuleResolver, ResourceResolver},
 };
 use move_prover_test_utils::{baseline_test::verify_or_update_baseline, extract_test_directives};
+use move_vm_runtime::data_cache::TransactionDataCache;
 use move_vm_test_utils::gas_schedule::GasStatus;
 use std::{
     cell::RefCell,
@@ -141,7 +142,7 @@ impl Harness {
 
     fn publish_module(
         &self,
-        session: &mut AsyncSession<HarnessProxy>,
+        session: &mut AsyncSession<TransactionDataCache<'_, '_, HarnessProxy>>,
         id: &IdentStr,
         gas: &mut GasStatus,
         done: &mut BTreeSet<Identifier>,

--- a/language/move-vm/integration-tests/src/tests/instantiation_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/instantiation_tests.rs
@@ -24,6 +24,7 @@ use move_core_types::{
     vm_status::StatusCode,
 };
 use move_vm_runtime::{
+    data_cache::TransactionDataCache,
     move_vm::MoveVM,
     session::{SerializedReturnValues, Session},
 };
@@ -192,7 +193,7 @@ fn test_runner(
     test_name: &str,
     entry_spec: fn(
         AccountAddress,
-        &mut Session<InMemoryStorage>,
+        &mut Session<TransactionDataCache<'_, '_, InMemoryStorage>>,
     ) -> (ModuleId, Identifier, Vec<TypeTag>),
     check_result: fn(u128, u128) -> bool,
 ) {
@@ -377,7 +378,7 @@ fn test_instantiation_deep_rec_gen_call() {
 //
 // Notice: this is not a particularly easy function to use. See example below on how to use it.
 fn make_module(
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<TransactionDataCache<'_, '_, InMemoryStorage>>,
     addr: AccountAddress,
     func_type_params_count: usize,
     locals_sig: Option<Signature>,
@@ -597,7 +598,7 @@ fn run_with_module(
     gas: &mut GasStatus,
     entry_spec: fn(
         AccountAddress,
-        &mut Session<InMemoryStorage>,
+        &mut Session<TransactionDataCache<'_, '_, InMemoryStorage>>,
     ) -> (ModuleId, Identifier, Vec<TypeTag>),
 ) -> (VMResult<SerializedReturnValues>, u128) {
     let addr = AccountAddress::from_hex_literal("0xcafe").unwrap();
@@ -626,7 +627,7 @@ fn run_with_module(
 // Call a simple load u8 and pop loop
 fn load_pop(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<TransactionDataCache<'_, '_, InMemoryStorage>>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     //
     // Module definition and publishing
@@ -667,7 +668,7 @@ fn get_load_pop() -> Vec<Bytecode> {
 // Call a vector<T> pack empty and pop with full instantiation
 fn vec_pack_instantiated(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<TransactionDataCache<'_, '_, InMemoryStorage>>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     //
     // Module definition and publishing
@@ -703,7 +704,7 @@ fn vec_pack_instantiated(
 // Call a vector<T> pack empty and pop with simple generic instantiation
 fn vec_pack_gen_simple(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<TransactionDataCache<'_, '_, InMemoryStorage>>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     //
     // Module definition and publishing
@@ -739,28 +740,28 @@ fn vec_pack_gen_simple(
 // Call a vector<T> pack empty and pop with deep generic instantiation
 fn vec_pack_gen_deep(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<TransactionDataCache<'_, '_, InMemoryStorage>>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     vec_pack_gen_deep_it(addr, session, 1)
 }
 
 fn vec_pack_gen_deep_50(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<TransactionDataCache<'_, '_, InMemoryStorage>>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     vec_pack_gen_deep_it(addr, session, 50)
 }
 
 fn vec_pack_gen_deep_500(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<TransactionDataCache<'_, '_, InMemoryStorage>>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     vec_pack_gen_deep_it(addr, session, 500)
 }
 
 fn vec_pack_gen_deep_it(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<TransactionDataCache<'_, '_, InMemoryStorage>>,
     snippet_rep: usize,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     const STRUCT_TY_PARAMS: usize = 3;
@@ -824,7 +825,7 @@ fn get_vec_pack(idx: u16) -> Vec<Bytecode> {
 // Call `Exists` on an instantiated generic and pop
 fn instantiated_gen_exists(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<TransactionDataCache<'_, '_, InMemoryStorage>>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     //
     // Module definition and publishing
@@ -860,7 +861,7 @@ fn instantiated_gen_exists(
 // Call `Exists` on a simple generic and pop
 fn simple_gen_exists(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<TransactionDataCache<'_, '_, InMemoryStorage>>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     //
     // Module definition and publishing
@@ -899,28 +900,28 @@ fn simple_gen_exists(
 // Call `Exists` on a deep generic and pop
 fn deep_gen_exists(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<TransactionDataCache<'_, '_, InMemoryStorage>>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     deep_gen_exists_it(addr, session, 1)
 }
 
 fn deep_gen_exists_50(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<TransactionDataCache<'_, '_, InMemoryStorage>>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     deep_gen_exists_it(addr, session, 50)
 }
 
 fn deep_gen_exists_500(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<TransactionDataCache<'_, '_, InMemoryStorage>>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     deep_gen_exists_it(addr, session, 500)
 }
 
 fn deep_gen_exists_it(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<TransactionDataCache<'_, '_, InMemoryStorage>>,
     snippet_rep: usize,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     const STRUCT_TY_PARAMS: usize = 3;
@@ -988,7 +989,7 @@ fn get_generic_exists() -> Vec<Bytecode> {
 // Call an instantiated generic function
 fn instantiated_gen_call(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<TransactionDataCache<'_, '_, InMemoryStorage>>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     //
     // Module definition and publishing
@@ -1024,7 +1025,7 @@ fn instantiated_gen_call(
 // Call simple generic function
 fn simple_gen_call(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<TransactionDataCache<'_, '_, InMemoryStorage>>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     //
     // Module definition and publishing
@@ -1060,28 +1061,28 @@ fn simple_gen_call(
 // Call deep instantiation generic function
 fn deep_gen_call(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<TransactionDataCache<'_, '_, InMemoryStorage>>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     deep_gen_call_it(addr, session, 1)
 }
 
 fn deep_gen_call_50(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<TransactionDataCache<'_, '_, InMemoryStorage>>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     deep_gen_call_it(addr, session, 50)
 }
 
 fn deep_gen_call_500(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<TransactionDataCache<'_, '_, InMemoryStorage>>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     deep_gen_call_it(addr, session, 500)
 }
 
 fn deep_gen_call_it(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<TransactionDataCache<'_, '_, InMemoryStorage>>,
     snippet_rep: usize,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     const STRUCT_TY_PARAMS: usize = 3;
@@ -1145,7 +1146,7 @@ fn get_generic_call_loop() -> Vec<Bytecode> {
 // Call an instantiated generic function
 fn instantiated_rec_gen_call(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<TransactionDataCache<'_, '_, InMemoryStorage>>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     //
     // Module definition and publishing
@@ -1181,7 +1182,7 @@ fn instantiated_rec_gen_call(
 // Call simple generic function
 fn simple_rec_gen_call(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<TransactionDataCache<'_, '_, InMemoryStorage>>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     //
     // Module definition and publishing
@@ -1217,7 +1218,7 @@ fn simple_rec_gen_call(
 // Call deep instantiation generic function
 fn deep_rec_gen_call(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<TransactionDataCache<'_, '_, InMemoryStorage>>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     const STRUCT_TY_PARAMS: usize = 3;
     const STRUCT_TY_ARGS_DEPTH: usize = 2;

--- a/language/move-vm/runtime/src/data_cache.rs
+++ b/language/move-vm/runtime/src/data_cache.rs
@@ -49,7 +49,12 @@ impl AccountDataCache {
 /// The Move VM takes a `DataStore` in input and this is the default and correct implementation
 /// for a data store related to a transaction. Clients should create an instance of this type
 /// and pass it to the Move VM.
-pub(crate) struct TransactionDataCache<'r, 'l, S> {
+pub trait TransactionCache {
+    fn into_effects(self) -> PartialVMResult<(ChangeSet, Vec<Event>)>;
+    fn num_mutated_accounts(&self, sender: &AccountAddress) -> u64;
+}
+
+pub struct TransactionDataCache<'r, 'l, S> {
     remote: &'r S,
     loader: &'l Loader,
     account_map: BTreeMap<AccountAddress, AccountDataCache>,
@@ -68,11 +73,25 @@ impl<'r, 'l, S: MoveResolver> TransactionDataCache<'r, 'l, S> {
         }
     }
 
+    fn get_mut_or_insert_with<'a, K, V, F>(map: &'a mut BTreeMap<K, V>, k: &K, gen: F) -> &'a mut V
+    where
+        F: FnOnce() -> (K, V),
+        K: Ord,
+    {
+        if !map.contains_key(k) {
+            let (k, v) = gen();
+            map.insert(k, v);
+        }
+        map.get_mut(k).unwrap()
+    }
+}
+
+impl<'r, 'l, S: MoveResolver> TransactionCache for TransactionDataCache<'r, 'l, S> {
     /// Make a write set from the updated (dirty, deleted) global resources along with
     /// published modules.
     ///
     /// Gives all proper guarantees on lifetime of global data as well.
-    pub(crate) fn into_effects(self) -> PartialVMResult<(ChangeSet, Vec<Event>)> {
+    fn into_effects(self) -> PartialVMResult<(ChangeSet, Vec<Event>)> {
         let mut change_set = ChangeSet::new();
         for (addr, account_data_cache) in self.account_map.into_iter() {
             let mut modules = BTreeMap::new();
@@ -137,7 +156,7 @@ impl<'r, 'l, S: MoveResolver> TransactionDataCache<'r, 'l, S> {
         Ok((change_set, events))
     }
 
-    pub(crate) fn num_mutated_accounts(&self, sender: &AccountAddress) -> u64 {
+    fn num_mutated_accounts(&self, sender: &AccountAddress) -> u64 {
         // The sender's account will always be mutated.
         let mut total_mutated_accounts: u64 = 1;
         for (addr, entry) in self.account_map.iter() {
@@ -146,18 +165,6 @@ impl<'r, 'l, S: MoveResolver> TransactionDataCache<'r, 'l, S> {
             }
         }
         total_mutated_accounts
-    }
-
-    fn get_mut_or_insert_with<'a, K, V, F>(map: &'a mut BTreeMap<K, V>, k: &K, gen: F) -> &'a mut V
-    where
-        F: FnOnce() -> (K, V),
-        K: Ord,
-    {
-        if !map.contains_key(k) {
-            let (k, v) = gen();
-            map.insert(k, v);
-        }
-        map.get_mut(k).unwrap()
     }
 }
 

--- a/language/move-vm/runtime/src/data_cache.rs
+++ b/language/move-vm/runtime/src/data_cache.rs
@@ -16,7 +16,7 @@ use move_core_types::{
     vm_status::StatusCode,
 };
 use move_vm_types::{
-    data_store::DataStore,
+    data_store::{DataStore, TransactionCache},
     loaded_data::runtime_types::Type,
     values::{GlobalValue, Value},
 };
@@ -49,11 +49,6 @@ impl AccountDataCache {
 /// The Move VM takes a `DataStore` in input and this is the default and correct implementation
 /// for a data store related to a transaction. Clients should create an instance of this type
 /// and pass it to the Move VM.
-pub trait TransactionCache {
-    fn into_effects(self) -> PartialVMResult<(ChangeSet, Vec<Event>)>;
-    fn num_mutated_accounts(&self, sender: &AccountAddress) -> u64;
-}
-
 pub struct TransactionDataCache<'r, 'l, S> {
     remote: &'r S,
     loader: &'l Loader,
@@ -64,7 +59,7 @@ pub struct TransactionDataCache<'r, 'l, S> {
 impl<'r, 'l, S: MoveResolver> TransactionDataCache<'r, 'l, S> {
     /// Create a `TransactionDataCache` with a `RemoteCache` that provides access to data
     /// not updated in the transaction.
-    pub(crate) fn new(remote: &'r S, loader: &'l Loader) -> Self {
+    pub fn new(remote: &'r S, loader: &'l Loader) -> Self {
         TransactionDataCache {
             remote,
             loader,

--- a/language/move-vm/runtime/src/loader.rs
+++ b/language/move-vm/runtime/src/loader.rs
@@ -469,7 +469,7 @@ impl ModuleCache {
 // entities. Each cache is protected by a `RwLock`. Operation in the Loader must be thread safe
 // (operating on values on the stack) and when cache needs updating the mutex must be taken.
 // The `pub(crate)` API is what a Loader offers to the runtime.
-pub(crate) struct Loader {
+pub struct Loader {
     scripts: RwLock<ScriptCache>,
     module_cache: RwLock<ModuleCache>,
     type_cache: RwLock<TypeCache>,

--- a/language/move-vm/runtime/src/move_vm.rs
+++ b/language/move-vm/runtime/src/move_vm.rs
@@ -5,13 +5,10 @@
 use std::{collections::BTreeSet, sync::Arc};
 
 use crate::{
-    config::VMConfig,
-    data_cache::{TransactionCache, TransactionDataCache},
-    native_extensions::NativeContextExtensions,
-    native_functions::NativeFunction,
-    runtime::VMRuntime,
-    session::Session,
+    config::VMConfig, data_cache::TransactionDataCache, native_extensions::NativeContextExtensions,
+    native_functions::NativeFunction, runtime::VMRuntime, session::Session,
 };
+
 use move_binary_format::{
     errors::{Location, VMResult},
     CompiledModule,
@@ -20,7 +17,7 @@ use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, language_storage::ModuleId,
     metadata::Metadata, resolver::MoveResolver,
 };
-use move_vm_types::data_store::DataStore;
+use move_vm_types::data_store::{DataStore, TransactionCache};
 
 pub struct MoveVM {
     runtime: VMRuntime,
@@ -74,21 +71,21 @@ impl MoveVM {
     }
 
     /// Create a new session, as in `new_session`, but provide a data store
-    pub fn new_session_with_store<'r, D: DataStore + TransactionCache>(
+    pub fn new_session_with_cache<'r, D: DataStore + TransactionCache>(
         &self,
-        data_store: D,
+        data_cache: D,
     ) -> Session<'r, '_, D> {
-        self.runtime.new_session_with_store(data_store)
+        self.runtime.new_session_with_cache(data_cache)
     }
 
     /// Create a new session, as in `new_session`, but provide a data store and native context extensions
-    pub fn new_session_with_store_and_extensions<'r, D: DataStore + TransactionCache>(
+    pub fn new_session_with_cache_and_extensions<'r, D: DataStore + TransactionCache>(
         &self,
-        data_store: D,
+        data_cache: D,
         extensions: NativeContextExtensions<'r>,
     ) -> Session<'r, '_, D> {
         self.runtime
-            .new_session_with_store_and_extensions(data_store, extensions)
+            .new_session_with_cache_and_extensions(data_cache, extensions)
     }
 
     /// Load a module into VM's code cache
@@ -149,5 +146,11 @@ impl MoveVM {
     ///   call this directly via the loader instead of the VM.
     pub fn get_module_metadata(&self, module: ModuleId, key: &[u8]) -> Option<Metadata> {
         self.runtime.loader().get_metadata(module, key)
+    }
+
+    /// Borrow runtime
+    #[cfg(test)]
+    pub(crate) fn runtime(&self) -> &VMRuntime {
+        &self.runtime
     }
 }

--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     config::VMConfig,
-    data_cache::{TransactionCache, TransactionDataCache},
+    data_cache::TransactionDataCache,
     interpreter::Interpreter,
     loader::{Function, Loader},
     native_extensions::NativeContextExtensions,
@@ -28,7 +28,7 @@ use move_core_types::{
     vm_status::StatusCode,
 };
 use move_vm_types::{
-    data_store::DataStore,
+    data_store::{DataStore, TransactionCache},
     gas::GasMeter,
     loaded_data::runtime_types::Type,
     values::{Locals, Reference, VMValueCast, Value},
@@ -70,21 +70,21 @@ impl VMRuntime {
         }
     }
 
-    pub fn new_session_with_store<'r, D: DataStore + TransactionCache>(
+    pub fn new_session_with_cache<'r, D: DataStore + TransactionCache>(
         &self,
-        data_store: D,
+        data_cache: D,
     ) -> Session<'r, '_, D> {
-        self.new_session_with_store_and_extensions(data_store, NativeContextExtensions::default())
+        self.new_session_with_cache_and_extensions(data_cache, NativeContextExtensions::default())
     }
 
-    pub fn new_session_with_store_and_extensions<'r, D: DataStore + TransactionCache>(
+    pub fn new_session_with_cache_and_extensions<'r, D: DataStore + TransactionCache>(
         &self,
-        data_store: D,
+        data_cache: D,
         native_extensions: NativeContextExtensions<'r>,
     ) -> Session<'r, '_, D> {
         Session {
             runtime: self,
-            data_cache: data_store,
+            data_cache,
             native_extensions,
         }
     }

--- a/language/move-vm/runtime/src/session.rs
+++ b/language/move-vm/runtime/src/session.rs
@@ -2,9 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    data_cache::TransactionCache, native_extensions::NativeContextExtensions, runtime::VMRuntime,
-};
+use crate::{native_extensions::NativeContextExtensions, runtime::VMRuntime};
 use move_binary_format::{
     compatibility::Compatibility,
     errors::*,
@@ -18,7 +16,7 @@ use move_core_types::{
     value::MoveTypeLayout,
 };
 use move_vm_types::{
-    data_store::DataStore,
+    data_store::{DataStore, TransactionCache},
     gas::GasMeter,
     loaded_data::runtime_types::{CachedStructIndex, StructType, Type},
 };

--- a/language/move-vm/runtime/src/session.rs
+++ b/language/move-vm/runtime/src/session.rs
@@ -3,8 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    data_cache::TransactionDataCache, native_extensions::NativeContextExtensions,
-    runtime::VMRuntime,
+    data_cache::TransactionCache, native_extensions::NativeContextExtensions, runtime::VMRuntime,
 };
 use move_binary_format::{
     compatibility::Compatibility,
@@ -16,7 +15,6 @@ use move_core_types::{
     effects::{ChangeSet, Event},
     identifier::IdentStr,
     language_storage::{ModuleId, TypeTag},
-    resolver::MoveResolver,
     value::MoveTypeLayout,
 };
 use move_vm_types::{
@@ -28,7 +26,7 @@ use std::{borrow::Borrow, sync::Arc};
 
 pub struct Session<'r, 'l, S> {
     pub(crate) runtime: &'l VMRuntime,
-    pub(crate) data_cache: TransactionDataCache<'r, 'l, S>,
+    pub(crate) data_cache: S,
     pub(crate) native_extensions: NativeContextExtensions<'r>,
 }
 
@@ -43,7 +41,7 @@ pub struct SerializedReturnValues {
     pub return_values: Vec<(Vec<u8>, MoveTypeLayout)>,
 }
 
-impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
+impl<'r, 'l, S: DataStore + TransactionCache> Session<'r, 'l, S> {
     /// Execute a Move function with the given arguments. This is mainly designed for an external
     /// environment to invoke system logic written in Move.
     ///

--- a/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
+++ b/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
@@ -34,6 +34,7 @@ use move_stdlib::move_stdlib_named_addresses;
 use move_symbol_pool::Symbol;
 use move_vm_runtime::{
     config::VMConfig,
+    data_cache::TransactionDataCache,
     move_vm::MoveVM,
     session::{SerializedReturnValues, Session},
 };
@@ -337,7 +338,10 @@ impl<'a> SimpleVMTestAdapter<'a> {
     fn perform_session_action<Ret>(
         &mut self,
         gas_budget: Option<u64>,
-        f: impl FnOnce(&mut Session<InMemoryStorage>, &mut GasStatus) -> VMResult<Ret>,
+        f: impl FnOnce(
+            &mut Session<TransactionDataCache<'_, '_, InMemoryStorage>>,
+            &mut GasStatus,
+        ) -> VMResult<Ret>,
         vm_config: VMConfig,
     ) -> VMResult<Ret> {
         // start session


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Refactor Session, support custom TransactionDataCache. Third party can give a custom data cache to create a move vm session.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)
