### PR TITLE
Add the run_spec_checker_for_script function to correctly transform CompiledScript into ModuleDefinition.

### DIFF
--- a/language/move-compiler/src/shared/mod.rs
+++ b/language/move-compiler/src/shared/mod.rs
@@ -133,7 +133,7 @@ pub fn shortest_cycle<'a, T: Ord + Hash>(
 pub type NamedAddressMap = BTreeMap<Symbol, NumericalAddress>;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NamedAddressMapIndex(usize);
+pub struct NamedAddressMapIndex(pub usize);
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct NamedAddressMaps(Vec<NamedAddressMap>);


### PR DESCRIPTION
The purpose of `run_spec_checker` is to transform `AnnotatedCompiledUnits` into the `ModuleEnv` structure. However, in cases where `AnnotatedCompiledUnits` contains a `CompiledScript` and, in our specific scenario where the `integration-test` is a single file not compiled with its dependencies, it is necessary to introduce the modules it depends on. This involves first transforming the dependent modules and then transforming the `CompiledScript`.