### PR TITLE
Expose vm runtime loader and some methods

### DIFF
--- a/language/move-vm/runtime/src/lib.rs
+++ b/language/move-vm/runtime/src/lib.rs
@@ -12,7 +12,7 @@
 
 pub mod data_cache;
 mod interpreter;
-mod loader;
+pub mod loader;
 pub mod logging;
 pub mod move_vm;
 pub mod native_extensions;

--- a/language/move-vm/runtime/src/loader.rs
+++ b/language/move-vm/runtime/src/loader.rs
@@ -932,7 +932,7 @@ impl Loader {
     // Helpers for loading and verification
     //
 
-    pub(crate) fn load_type(
+    pub fn load_type(
         &self,
         type_tag: &TypeTag,
         data_store: &(impl DataStore + ?Sized),
@@ -2826,7 +2826,7 @@ impl Loader {
 
 // Public APIs for external uses.
 impl Loader {
-    pub(crate) fn get_type_layout(
+    pub fn get_type_layout(
         &self,
         type_tag: &TypeTag,
         move_storage: &(impl DataStore + ?Sized),

--- a/language/move-vm/runtime/src/loader.rs
+++ b/language/move-vm/runtime/src/loader.rs
@@ -2806,11 +2806,11 @@ impl Loader {
         })
     }
 
-    pub(crate) fn type_to_type_tag(&self, ty: &Type) -> PartialVMResult<TypeTag> {
+    pub fn type_to_type_tag(&self, ty: &Type) -> PartialVMResult<TypeTag> {
         self.type_to_type_tag_impl(ty)
     }
 
-    pub(crate) fn type_to_type_layout(&self, ty: &Type) -> PartialVMResult<MoveTypeLayout> {
+    pub fn type_to_type_layout(&self, ty: &Type) -> PartialVMResult<MoveTypeLayout> {
         let mut count = 0;
         self.type_to_type_layout_impl(ty, &mut count, 1)
     }

--- a/language/move-vm/runtime/src/move_vm.rs
+++ b/language/move-vm/runtime/src/move_vm.rs
@@ -20,7 +20,7 @@ use move_core_types::{
 use move_vm_types::data_store::{DataStore, TransactionCache};
 
 pub struct MoveVM {
-    runtime: VMRuntime,
+    pub runtime: VMRuntime,
 }
 
 impl MoveVM {
@@ -149,8 +149,7 @@ impl MoveVM {
     }
 
     /// Borrow runtime
-    #[cfg(test)]
-    pub(crate) fn runtime(&self) -> &VMRuntime {
+    pub fn runtime(&self) -> &VMRuntime {
         &self.runtime
     }
 }

--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -37,8 +37,8 @@ use std::{borrow::Borrow, collections::BTreeSet, sync::Arc};
 use tracing::warn;
 
 /// An instantiation of the MoveVM.
-pub(crate) struct VMRuntime {
-    loader: Loader,
+pub struct VMRuntime {
+    pub loader: Loader,
 }
 
 impl VMRuntime {
@@ -502,7 +502,7 @@ impl VMRuntime {
         )
     }
 
-    pub(crate) fn loader(&self) -> &Loader {
+    pub fn loader(&self) -> &Loader {
         &self.loader
     }
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We want to implement custom TransactionDataCache outside Move project. In Rooch, we need reference vm runtime loader to get `Type` and `MoveTypeLayout` through `Loader::get_type_layout` and `Loader::load_type`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)
