### PR TITLE
Add builder for ErrmapOptions

### DIFF
--- a/language/move-prover/move-errmapgen/src/errmapgen.rs
+++ b/language/move-prover/move-errmapgen/src/errmapgen.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{bail, Result};
-use move_command_line_common::files::MOVE_ERROR_DESC_EXTENSION;
 use move_core_types::{
     account_address::AccountAddress,
     errmap::{ErrorDescription, ErrorMapping},
@@ -28,15 +27,54 @@ pub struct ErrmapOptions {
     pub output_file: String,
 }
 
-impl Default for ErrmapOptions {
-    fn default() -> Self {
-        Self {
-            error_prefix: "E".to_string(),
-            error_category_module: ModuleId::new(
-                AccountAddress::from_hex_literal("0x1").unwrap(),
-                Identifier::new("errors").unwrap(),
-            ),
-            output_file: MOVE_ERROR_DESC_EXTENSION.to_string(),
+impl ErrmapOptions {
+    // Create a builder for ErrmapOptions
+    pub fn builder() -> ErrmapOptionsBuilder {
+        ErrmapOptionsBuilder::new()
+    }
+}
+
+// Define a builder struct to configure ErrmapOptions
+pub struct ErrmapOptionsBuilder {
+    error_prefix: Option<String>,
+    error_category_module: Option<ModuleId>,
+    output_file: Option<String>,
+}
+
+impl ErrmapOptionsBuilder {
+    // Initialize the builder with default values
+    fn new() -> Self {
+        ErrmapOptionsBuilder {
+            error_prefix: None,
+            error_category_module: None,
+            output_file: None,
+        }
+    }
+
+    // Set the error prefix
+    pub fn error_prefix(mut self, prefix: &str) -> Self {
+        self.error_prefix = Some(prefix.to_owned());
+        self
+    }
+
+    // Set the error category module
+    pub fn error_category_module(mut self, module: ModuleId) -> Self {
+        self.error_category_module = Some(module);
+        self
+    }
+
+    // Set the output file
+    pub fn output_file(mut self, file: &str) -> Self {
+        self.output_file = Some(file.to_owned());
+        self
+    }
+
+    // Build the ErrmapOptions instance
+    pub fn build(self) -> ErrmapOptions {
+        ErrmapOptions {
+            error_prefix: self.error_prefix.expect("Error prefix not set"),
+            error_category_module: self.error_category_module.expect("Error category module not set"),
+            output_file: self.output_file.expect("Output file not set"),
         }
     }
 }
@@ -140,3 +178,4 @@ impl<'env> ErrmapGen<'env> {
         self.env.symbol_pool().string(symbol)
     }
 }
+

--- a/language/move-prover/move-errmapgen/src/errmapgen.rs
+++ b/language/move-prover/move-errmapgen/src/errmapgen.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{bail, Result};
+use move_command_line_common::files::MOVE_ERROR_DESC_EXTENSION;
 use move_core_types::{
     account_address::AccountAddress,
     errmap::{ErrorDescription, ErrorMapping},
@@ -31,6 +32,20 @@ impl ErrmapOptions {
     // Create a builder for ErrmapOptions
     pub fn builder() -> ErrmapOptionsBuilder {
         ErrmapOptionsBuilder::new()
+    }
+}
+
+impl Default for ErrmapOptions {
+    // Create a default ErrmapOptions
+    fn default() -> Self {
+        Self {
+            error_prefix: "E".to_string(),
+            error_category_module: ModuleId::new(
+                AccountAddress::from_hex_literal("0x1").unwrap(),
+                Identifier::new("errors").unwrap(),
+            ),
+            output_file: MOVE_ERROR_DESC_EXTENSION.to_string(),
+        }
     }
 }
 

--- a/language/move-prover/move-errmapgen/src/errmapgen.rs
+++ b/language/move-prover/move-errmapgen/src/errmapgen.rs
@@ -50,6 +50,7 @@ impl Default for ErrmapOptions {
 }
 
 // Define a builder struct to configure ErrmapOptions
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ErrmapOptionsBuilder {
     error_prefix: Option<String>,
     error_category_module: Option<ModuleId>,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Add a custom builder for ErrmapOptions to build custom error map.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes.

## Test Plan

N/A